### PR TITLE
Refine event planner UI with Tailwind components

### DIFF
--- a/src/components/AddEvent.tsx
+++ b/src/components/AddEvent.tsx
@@ -1,0 +1,34 @@
+import { FormEvent } from 'react';
+
+interface AddEventProps {
+  onAdd: (name: string) => void;
+}
+
+export function AddEvent({ onAdd }: AddEventProps) {
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    const eventName = formData.get('eventName') as string;
+    if (eventName) {
+      onAdd(eventName);
+      event.currentTarget.reset();
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex gap-2 mb-4">
+      <input
+        name="eventName"
+        placeholder="New event"
+        className="flex-1 rounded border border-gray-300 px-3 py-2 focus:border-blue-500 focus:outline-none"
+      />
+      <button
+        type="submit"
+        className="rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-600"
+      >
+        Add
+      </button>
+    </form>
+  );
+}
+

--- a/src/components/EventItem.tsx
+++ b/src/components/EventItem.tsx
@@ -1,0 +1,25 @@
+interface Event {
+  id: string;
+  name: string;
+}
+
+interface EventItemProps {
+  event: Event;
+  onDelete: (id: string) => void;
+}
+
+export function EventItem({ event, onDelete }: EventItemProps) {
+  return (
+    <li className="flex items-center justify-between rounded bg-gray-50 px-4 py-2 hover:bg-gray-100">
+      <span>{event.name}</span>
+      <button
+        onClick={() => onDelete(event.id)}
+        className="text-red-500 hover:text-red-700"
+        aria-label="Delete event"
+      >
+        🗑️
+      </button>
+    </li>
+  );
+}
+

--- a/src/components/EventList.tsx
+++ b/src/components/EventList.tsx
@@ -1,0 +1,26 @@
+import { EventItem } from './EventItem';
+
+interface Event {
+  id: string;
+  name: string;
+}
+
+interface EventListProps {
+  events: Event[];
+  onDelete: (id: string) => void;
+}
+
+export function EventList({ events, onDelete }: EventListProps) {
+  if (events.length === 0) {
+    return <p className="text-center text-gray-500">No events yet</p>;
+  }
+
+  return (
+    <ul className="space-y-2">
+      {events.map((event) => (
+        <EventItem key={event.id} event={event} onDelete={onDelete} />
+      ))}
+    </ul>
+  );
+}
+

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,11 +1,12 @@
 import { createFileRoute } from '@tanstack/react-router';
-import '../App.css';
 import {
   createCollection,
   localStorageCollectionOptions,
   useLiveQuery,
 } from '@tanstack/react-db';
 import z from 'zod';
+import { AddEvent } from '../components/AddEvent';
+import { EventList } from '../components/EventList';
 
 const eventsSchema = z.object({
   id: z.string(),
@@ -29,8 +30,8 @@ export const Route = createFileRoute('/')({
 
 function App() {
   return (
-    <div className="App">
-      <h1>Event Planner</h1>
+    <div className="flex min-h-screen flex-col items-center bg-gray-100 p-4">
+      <h1 className="mt-8 text-4xl font-bold text-gray-800">Event Planner</h1>
       <Events />
     </div>
   );
@@ -43,24 +44,6 @@ function Events() {
       .orderBy(({ event }) => event.createdAt, 'asc')
   );
 
-  const deleteEvent = (id: string) => eventsCollection.delete(id);
-
-  return (
-    <div>
-      <p>Events</p>
-      <AddEvent />
-      <ul>
-        {events.map((event) => (
-          <li>
-            {event.name} <span onClick={() => deleteEvent(event.id)}>🛑</span>
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
-}
-
-function AddEvent() {
   const addEvent = (eventName: string) => {
     eventsCollection.insert({
       id: crypto.randomUUID(),
@@ -70,24 +53,12 @@ function AddEvent() {
     });
   };
 
+  const deleteEvent = (id: string) => eventsCollection.delete(id);
+
   return (
-    <div>
-      <form
-        onSubmit={(event) => {
-          event.preventDefault();
-          const formData = new FormData(event.currentTarget);
-          const eventName = formData.get('eventName') as string;
-          if (eventName) {
-            addEvent(eventName);
-            event.currentTarget.reset();
-          }
-        }}
-      >
-        <input name="eventName" className="border border-black"></input>
-        <button className="border px-2 border-black" type="submit">
-          Add event
-        </button>
-      </form>
+    <div className="mt-6 w-full max-w-md rounded-xl bg-white p-6 shadow">
+      <AddEvent onAdd={addEvent} />
+      <EventList events={events} onDelete={deleteEvent} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Restyle Event Planner page using Tailwind
- Extract AddEvent, EventItem, and EventList components
- Display events in card-like layout

## Testing
- `pnpm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68bed296ebc08329ae8e086881bede5a