### PR TITLE
Refine event planner UI with responsive gradients

### DIFF
--- a/src/components/AddEvent.tsx
+++ b/src/components/AddEvent.tsx
@@ -1,0 +1,37 @@
+import { FormEvent } from 'react';
+
+interface AddEventProps {
+  onAdd: (name: string) => void;
+}
+
+export function AddEvent({ onAdd }: AddEventProps) {
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    const eventName = formData.get('eventName') as string;
+    if (eventName) {
+      onAdd(eventName);
+      event.currentTarget.reset();
+    }
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="mb-4 flex flex-col gap-2 sm:flex-row"
+    >
+      <input
+        name="eventName"
+        placeholder="New event"
+        className="flex-1 rounded border border-gray-300/50 bg-white/70 px-3 py-2 shadow-sm backdrop-blur-sm focus:border-indigo-500 focus:outline-none"
+      />
+      <button
+        type="submit"
+        className="w-full rounded bg-gradient-to-r from-indigo-500 to-purple-500 px-4 py-2 text-white shadow hover:from-indigo-600 hover:to-purple-600 sm:w-auto"
+      >
+        Add
+      </button>
+    </form>
+  );
+}
+

--- a/src/components/EventItem.tsx
+++ b/src/components/EventItem.tsx
@@ -1,0 +1,38 @@
+interface Event {
+  id: string;
+  name: string;
+}
+
+interface EventItemProps {
+  event: Event;
+  onDelete: (id: string) => void;
+}
+
+export function EventItem({ event, onDelete }: EventItemProps) {
+  return (
+    <li className="group flex items-center justify-between rounded-lg bg-white/70 px-4 py-2 shadow-sm backdrop-blur-sm transition-colors hover:bg-white/90">
+      <span>{event.name}</span>
+      <button
+        onClick={() => onDelete(event.id)}
+        className="opacity-0 transition-opacity group-hover:opacity-100 text-red-500 hover:text-red-700"
+        aria-label="Delete event"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          className="h-5 w-5"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.166L19.5 19.5a2.25 2.25 0 01-2.244 2.25h-10.5A2.25 2.25 0 014.5 19.5L5.772 5.79m13.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0L6.5 4.5m0 0A2.25 2.25 0 018.737 3h6.513A2.25 2.25 0 0117.487 4.5m-10.987 0h10.987"
+          />
+        </svg>
+      </button>
+    </li>
+  );
+}
+

--- a/src/components/EventList.tsx
+++ b/src/components/EventList.tsx
@@ -1,0 +1,26 @@
+import { EventItem } from './EventItem';
+
+interface Event {
+  id: string;
+  name: string;
+}
+
+interface EventListProps {
+  events: Event[];
+  onDelete: (id: string) => void;
+}
+
+export function EventList({ events, onDelete }: EventListProps) {
+  if (events.length === 0) {
+    return <p className="text-center text-gray-500">No events yet</p>;
+  }
+
+  return (
+    <ul className="space-y-2">
+      {events.map((event) => (
+        <EventItem key={event.id} event={event} onDelete={onDelete} />
+      ))}
+    </ul>
+  );
+}
+

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,11 +1,12 @@
 import { createFileRoute } from '@tanstack/react-router';
-import '../App.css';
 import {
   createCollection,
   localStorageCollectionOptions,
   useLiveQuery,
 } from '@tanstack/react-db';
 import z from 'zod';
+import { AddEvent } from '../components/AddEvent';
+import { EventList } from '../components/EventList';
 
 const eventsSchema = z.object({
   id: z.string(),
@@ -29,8 +30,10 @@ export const Route = createFileRoute('/')({
 
 function App() {
   return (
-    <div className="App">
-      <h1>Event Planner</h1>
+    <div className="flex min-h-screen flex-col items-center bg-gradient-to-br from-indigo-50 via-white to-purple-50 p-4">
+      <h1 className="mt-8 bg-gradient-to-r from-indigo-600 to-purple-600 bg-clip-text text-4xl font-bold text-transparent">
+        Event Planner
+      </h1>
       <Events />
     </div>
   );
@@ -43,24 +46,6 @@ function Events() {
       .orderBy(({ event }) => event.createdAt, 'asc')
   );
 
-  const deleteEvent = (id: string) => eventsCollection.delete(id);
-
-  return (
-    <div>
-      <p>Events</p>
-      <AddEvent />
-      <ul>
-        {events.map((event) => (
-          <li>
-            {event.name} <span onClick={() => deleteEvent(event.id)}>🛑</span>
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
-}
-
-function AddEvent() {
   const addEvent = (eventName: string) => {
     eventsCollection.insert({
       id: crypto.randomUUID(),
@@ -70,24 +55,12 @@ function AddEvent() {
     });
   };
 
+  const deleteEvent = (id: string) => eventsCollection.delete(id);
+
   return (
-    <div>
-      <form
-        onSubmit={(event) => {
-          event.preventDefault();
-          const formData = new FormData(event.currentTarget);
-          const eventName = formData.get('eventName') as string;
-          if (eventName) {
-            addEvent(eventName);
-            event.currentTarget.reset();
-          }
-        }}
-      >
-        <input name="eventName" className="border border-black"></input>
-        <button className="border px-2 border-black" type="submit">
-          Add event
-        </button>
-      </form>
+    <div className="mt-6 w-full max-w-md rounded-xl border border-white/60 bg-white/80 p-6 shadow-xl backdrop-blur-lg">
+      <AddEvent onAdd={addEvent} />
+      <EventList events={events} onDelete={deleteEvent} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Apply gradient background and blurred card styling
- Make AddEvent form responsive with gradient button
- Hide delete action until item hover using SVG icon

## Testing
- `pnpm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68bed296ebc08329ae8e086881bede5a